### PR TITLE
changes to make interaction with the Biostrings classes more easy as …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Efficient manipulation of biological strings
 Description: Memory efficient string containers, string matching
 	algorithms, and other utilities, for fast manipulation of large
 	biological sequences or sets of sequences.
-Version: 2.51.4
+Version: 2.51.5
 Encoding: UTF-8
 Author: H. Pagès, P. Aboyoun, R. Gentleman, and S. DebRoy
 Maintainer: H. Pagès <hpages@fredhutch.org>

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -57,7 +57,7 @@ export(
     DNA_BASES, RNA_BASES, DNA_ALPHABET, RNA_ALPHABET,
 
     ## seqtype.R:
-    seqtype, "seqtype<-", get_seqtype_conversion_lookup, alphabet,
+    seqtype, "seqtype<-", get_seqtype_conversion_lookup, alphabet, xscodes,
 
     ## XString-class.R:
     extract_character_from_XString_by_positions,

--- a/R/XStringSet-class.R
+++ b/R/XStringSet-class.R
@@ -81,7 +81,7 @@ setMethod("width", "character",
     {
         if (any(is.na(x)))
             stop("NAs in 'x' are not supported")
-        nchar(x, type="bytes")
+        nchar(x, type="chars")
     }
 )
 

--- a/R/matchLRPatterns.R
+++ b/R/matchLRPatterns.R
@@ -37,7 +37,7 @@ setMethod("matchLRPatterns", "XString",
             }
         }
         ans_width <- ans_end - ans_start + 1L
-        unsafe.newXStringViews(subject, ans_start, ans_width)
+        Views(subject, start = ans_start, width = ans_width)
     }
 )
 
@@ -84,7 +84,7 @@ setMethod("matchLRPatterns", "XStringViews",
                 ans_width <- rep.int(width(Lmatches), Rcounts) + Roffset
             }
         }
-        unsafe.newXStringViews(subject(subject), ans_start, ans_width)
+        Views(subject(subject), start = ans_start, width = ans_width)
     }
 )
 

--- a/R/matchPattern.R
+++ b/R/matchPattern.R
@@ -142,7 +142,7 @@ gregexpr2 <- function(pattern, text)
                    PACKAGE="Biostrings")
     if (count.only)
         return(C_ans)
-    unsafe.newXStringViews(subject, start(C_ans), width(C_ans))
+    Views(subject, start = start(C_ans), width = width(C_ans))
 }
 
 .XStringViews.matchPattern <- function(pattern, subject,
@@ -170,7 +170,7 @@ gregexpr2 <- function(pattern, text)
                    PACKAGE="Biostrings")
     if (count.only)
         return(C_ans)
-    unsafe.newXStringViews(subject(subject), start(C_ans), width(C_ans))
+    Views(subject(subject), start = start(C_ans), width = width(C_ans))
 }
 
 

--- a/R/seqtype.R
+++ b/R/seqtype.R
@@ -43,14 +43,22 @@ setGeneric("seqtype<-", signature="x",
 
 xsbaseclass <- function(x) paste(seqtype(x), "String", sep="")
 
-xscodes <- function(x, baseOnly=FALSE)
-{
-    switch(seqtype(x),
-        DNA=DNAcodes(baseOnly),
-        RNA=RNAcodes(baseOnly),
-        0:255
-    )
-}
+setGeneric("xscodes", signature = "x",
+    function(x, baseOnly = FALSE, ...) standardGeneric("xscodes")
+)
+
+setMethod("xscodes","ANY",
+    function(x, baseOnly){
+        if (!isTRUEorFALSE(baseOnly))
+            stop("'baseOnly' must be TRUE or FALSE")
+        seqtype <- seqtype(x)
+        switch(seqtype,
+               DNA=DNAcodes(baseOnly),
+               RNA=RNAcodes(baseOnly),
+               0:255
+        )
+    }
+)
 
 xscodec <- function(x)
 {

--- a/man/Biostrings-internals.Rd
+++ b/man/Biostrings-internals.Rd
@@ -21,6 +21,7 @@
 % seqtype.R (put aliases for specific methods in corresponding man pages):
 \alias{seqtype}
 \alias{seqtype<-}
+\alias{xscodes}
 \alias{get_seqtype_conversion_lookup}
 
 % XString-class.R:


### PR DESCRIPTION
…proposed during review of the Modstrings package. This includes following changes: xscodes generic and default function added, use of the normal Views() constructor instead of the previously used Biostrings internal constructor function for the match(LR)Pattern function.

This is redo of PR #21, in which I made a mistake updating the fork during development. This lead to conflicts during merging and messed up history.