### PR TITLE
Remove cast to integer

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -4,8 +4,6 @@ N50 <- function(csizes)
 {
     if (!is.numeric(csizes))
         stop("'csizes' must be a vector containing the contig sizes")
-    if (!is.integer(csizes))
-        csizes <- as.integer(csizes)
     decreasing_csizes <- sort(csizes, decreasing=TRUE)
     tmp <- cumsum(decreasing_csizes)
     total_size <- tmp[length(tmp)]

--- a/R/misc.R
+++ b/R/misc.R
@@ -4,6 +4,9 @@ N50 <- function(csizes)
 {
     if (!is.numeric(csizes))
         stop("'csizes' must be a vector containing the contig sizes")
+    #If only integer, then genome size maxes out at 2.1Gbp, so coerce to double:
+    if(is.integer(csizes))
+        csizes <- as.numeric(csizes)
     decreasing_csizes <- sort(csizes, decreasing=TRUE)
     tmp <- cumsum(decreasing_csizes)
     total_size <- tmp[length(tmp)]


### PR DESCRIPTION
R's integers have long precision, meaning they max out around 2.14 x 10^9. Many genomes (e.g. human) and other data sets that are desirable to compute N50s for (e.g. long-read sequence data) have cumulative sizes far in excess of this. For this function to be able to operate on these larger data sets, it needs to leave the data in numeric form (ie double precision).