### PR TITLE
bugfix for compact ellipsis on windows system

### DIFF
--- a/R/XString-class.R
+++ b/R/XString-class.R
@@ -330,7 +330,7 @@ setMethod("as.vector", "XString",
 ### The "show" method.
 ###
 
-compact_ellipsis <- rawToChar(as.raw(c(0xe2, 0x80, 0xa6)))
+compact_ellipsis <- intToUtf8(0x2026L)
 
 ### NOT exported but used in the BSgenome package.
 ### 'x' must be a single character string, or an XString or

--- a/R/add_colors.R
+++ b/R/add_colors.R
@@ -40,7 +40,7 @@ make_DNA_AND_RNA_COLORED_LETTERS <- function()
 {
     ans <- vapply(x,
         function(xi) {
-            xi <- safeExplode(xi)
+            xi <- strsplit(xi,"")[[1L]]
             m <- match(xi, names(DNA_AND_RNA_COLORED_LETTERS))
             match_idx <- which(!is.na(m))
             xi[match_idx] <- DNA_AND_RNA_COLORED_LETTERS[m[match_idx]]


### PR DESCRIPTION
On windows the compact ellipsis is now shown correctly due to encoding change in S4Vectors::safeExplode. Solution works both on Windows and Linux. macOS was not tested.