### PR TITLE
This commit should fix the problem with the findPalindromes function …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Efficient manipulation of biological strings
 Description: Memory efficient string containers, string matching
 	algorithms, and other utilities, for fast manipulation of large
 	biological sequences or sets of sequences.
-Version: 2.54.0
+Version: 2.54.1
 Encoding: UTF-8
 Author: H. Pagès, P. Aboyoun, R. Gentleman, and S. DebRoy
 Maintainer: H. Pagès <hpages@fredhutch.org>

--- a/inst/unitTests/test_findPalindromes.R
+++ b/inst/unitTests/test_findPalindromes.R
@@ -16,6 +16,10 @@ test_findPalindromes_on_non_nucleotide_sequence <- function()
     text3 <- BString("AATAAACTNTCAAATYCCY")
     current <- findPalindromes(text3, min.armlength=2)
     checkIdentical(IRanges(c(1, 3, 16), c(5, 15, 19)), ranges(current))
+
+    text4 <- BString("i45hgfe7d321c3b4a56789uvwWVU98765A4B3C123D7EFGH54I")
+    current <- findPalindromes(text4, min.armlength = 5, max.looplength = length(text4), max.mismatch = 3)
+    checkIdentical(IRanges(c(18, 16, 14, 10, 8, 7, 6, 2, 1), c(33, 35, 37, 41, 43, 44, 45, 49, 50)), ranges(current))
 }
 
 test_findPalindromes_on_nucleotide_sequence <- function()

--- a/src/find_palindromes.c
+++ b/src/find_palindromes.c
@@ -22,25 +22,40 @@ static void get_find_palindromes_at(const char *x, int x_len,
 	int i1, int i2, int max_loop_len1, int min_arm_len, int max_nmis,
 	const int *lkup, int lkup_len)
 {
-	int arm_len, valid_indices;
+	int arm_len, valid_indices, nmis, first_mis1, first_mis2;
 	char c1, c2;
 
 	arm_len = 0;
+	nmis = 0;
 	while (((valid_indices = i1 >= 0 && i2 < x_len) &&
                 i2 - i1 <= max_loop_len1) || arm_len != 0)
 	{
 		if (valid_indices) {
 			c1 = x[i1];
 			c2 = x[i2];
+			/* Keep track of the index for the first mismatch in a palindrome arm search. */
+			if (nmis == 0 && !is_match(c1, c2, lkup, lkup_len)) {
+				first_mis1 = i1;
+				first_mis2 = i2;
+			}
 			if (is_match(c1, c2, lkup, lkup_len) ||
-			    max_nmis-- > 0) {
+			    nmis++ < max_nmis) {
 				arm_len++;
 				goto next;
 			}
 		}
 		if (arm_len >= min_arm_len)
 			_report_match(i1 + 2, i2 - i1 - 1);
+		/* If the search has not reached the end of the subject string,
+		 * or if it reached the end of the string but found a mismatch it can't include,
+		 * reset it to the first mismatch in the previous palindrome arm before continuing to search.
+		 */
+		if ((i1 > 0 && i2 + 1 < x_len) || nmis > max_nmis) {
+			i1 = first_mis1;
+			i2 = first_mis2;
+		}
 		arm_len = 0;
+		nmis = 0;
 	next:
 		i1--;
 		i2++;


### PR DESCRIPTION
…that caused it to not reliably find longer palindromes because it counted mismatches within the loop spacer.

The function now keeps track of where the first mismatch in its current search for a palindrome arm occured, and starts searching at that location whenever its current arm ends.

TODO: The function could be made significantly faster by using a deque to keep track of mismatches rather than rechecking indices that have already been checked.