### PR TITLE
findPalindromes - min.looplength and allow.wobble

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ biocViews: SequenceMatching, Alignment, Sequencing, Genetics,
 	DataImport, DataRepresentation, Infrastructure
 URL: https://bioconductor.org/packages/Biostrings
 BugReports: https://github.com/Bioconductor/Biostrings/issues
-Version: 2.59.0
+Version: 2.59.1
 License: Artistic-2.0
 Encoding: UTF-8
 Author: H. Pagès, P. Aboyoun, R. Gentleman, and S. DebRoy

--- a/R/findPalindromes.R
+++ b/R/findPalindromes.R
@@ -144,7 +144,7 @@ setMethod("findPalindromes", "MaskedXString",
 {
     max.mismatch <- normargMaxMismatch(max.mismatch)
     armlength <- .Call2("palindrome_arm_length",
-                        x, max.mismatch, allow.wobble, L2R_lkup,
+                        x, 1L, length(x), max.mismatch, allow.wobble, L2R_lkup,
                         PACKAGE="Biostrings")
     if (armlength == 0L)
         stop("'x' is not a palindrome (no arms found)")
@@ -180,9 +180,19 @@ setMethod("palindromeArmLength", "XStringViews",
     {
         if (length(x) == 0)
             return(integer(0))
-        sapply(seq_len(length(x)),
-               function(i)
-                   palindromeArmLength(x[[i]], max.mismatch=max.mismatch, allow.wobble=allow.wobble))
+        
+        a <- attributes(x)
+        if (is(a$subject, "DNAString") ||
+        	    is(a$subject, "RNAString")) {
+        	    	L2R_lkup <- .get_DNAorRNA_palindrome_L2R_lkup()
+        	} else {
+        	    L2R_lkup <- NULL
+        	}
+        
+        max.mismatch <- normargMaxMismatch(max.mismatch)
+        .Call2("palindrome_arm_length",
+                            a$subject, start(a$ranges), end(a$ranges), max.mismatch, allow.wobble, L2R_lkup,
+                            PACKAGE="Biostrings")
     }
 )
 

--- a/R/findPalindromes.R
+++ b/R/findPalindromes.R
@@ -42,6 +42,8 @@
         stop("'min.looplength' must be a non-negative integer")
     if (!is.logical(allow.wobble))
         stop("'allow.wobble' must be a logical")
+    if (allow.wobble && !is.null(L2R_lkup))
+    	    stop("subject must be DNA or RNA if 'allow.wobble' is TRUE")
     ## check max.mismatch
     max.mismatch <- normargMaxMismatch(max.mismatch)
     C_ans <- .Call2("find_palindromes",

--- a/R/findPalindromes.R
+++ b/R/findPalindromes.R
@@ -18,7 +18,7 @@
 ### Return an IRanges object.
 .find_palindromes <- function(subject, min.armlength,
                               max.looplength, min.looplength,
-                              max.mismatch, L2R_lkup)
+                              max.mismatch, allow.wobble, L2R_lkup)
 {
     ## check min.armlength
     if (!isSingleNumber(min.armlength))
@@ -40,14 +40,14 @@
         stop("'min.looplength' must be <= 'max.looplength'")
     if (min.looplength < 0)
         stop("'min.looplength' must be a non-negative integer")
-    if (min.looplength >= 1)
-        stop("'min.looplength' >= 1 not yet supported (will be very soon)")
+    if (!is.logical(allow.wobble))
+        stop("'allow.wobble' must be a logical")
     ## check max.mismatch
     max.mismatch <- normargMaxMismatch(max.mismatch)
     C_ans <- .Call2("find_palindromes",
                     subject,
                     min.armlength, max.looplength, max.mismatch,
-                    L2R_lkup,
+                    min.looplength, allow.wobble, L2R_lkup,
                     PACKAGE="Biostrings")
     unsafe.newXStringViews(subject, start(C_ans), width(C_ans))
 }
@@ -55,49 +55,52 @@
 setGeneric("findPalindromes", signature="subject",
     function(subject, min.armlength=4,
                       max.looplength=1, min.looplength=0,
-                      max.mismatch=0)
+                      max.mismatch=0, allow.wobble=FALSE)
         standardGeneric("findPalindromes")
 )
 
 setMethod("findPalindromes", "XString",
     function(subject, min.armlength=4,
                       max.looplength=1, min.looplength=0,
-                      max.mismatch=0)
+                      max.mismatch=0, allow.wobble=FALSE)
     {
         .find_palindromes(subject, min.armlength,
                           max.looplength, min.looplength,
-                          max.mismatch, NULL)
+                          max.mismatch, allow.wobble,
+                          NULL)
     }
 )
 
 setMethod("findPalindromes", "DNAString",
     function(subject, min.armlength=4,
                       max.looplength=1, min.looplength=0,
-                      max.mismatch=0)
+                      max.mismatch=0, allow.wobble=FALSE)
     {
         L2R_lkup <- .get_DNAorRNA_palindrome_L2R_lkup()
         .find_palindromes(subject, min.armlength,
                           max.looplength, min.looplength,
-                          max.mismatch, L2R_lkup)
+                          max.mismatch, allow.wobble,
+                          L2R_lkup)
     }
 )
 
 setMethod("findPalindromes", "RNAString",
     function(subject, min.armlength=4,
                       max.looplength=1, min.looplength=0,
-                      max.mismatch=0)
+                      max.mismatch=0, allow.wobble=FALSE)
     {
         L2R_lkup <- .get_DNAorRNA_palindrome_L2R_lkup()
         .find_palindromes(subject, min.armlength,
                           max.looplength, min.looplength,
-                          max.mismatch, L2R_lkup)
+                          max.mismatch, allow.wobble,
+                          L2R_lkup)
     }
 )
 
 setMethod("findPalindromes", "XStringViews",
     function(subject, min.armlength=4,
                       max.looplength=1, min.looplength=0,
-                      max.mismatch=0)
+                      max.mismatch=0, allow.wobble=FALSE)
     {
         tmp <- vector(mode="list", length=length(subject))
         offsets <- start(subject) - 1L
@@ -106,7 +109,8 @@ setMethod("findPalindromes", "XStringViews",
                                     min.armlength=min.armlength,
                                     max.looplength=max.looplength,
                                     min.looplength=min.looplength,
-                                    max.mismatch=max.mismatch)
+                                    max.mismatch=max.mismatch,
+                                    allow.wobble=allow.wobble)
             tmp[[i]] <- shift(ranges(pals), shift=offsets[i])
         }
         ans_ranges <- do.call("c", tmp)
@@ -118,13 +122,14 @@ setMethod("findPalindromes", "XStringViews",
 setMethod("findPalindromes", "MaskedXString",
     function(subject, min.armlength=4,
                       max.looplength=1, min.looplength=0,
-                      max.mismatch=0)
+                      max.mismatch=0, allow.wobble=FALSE)
     {
         findPalindromes(toXStringViewsOrXString(subject),
                         min.armlength=min.armlength,
                         max.looplength=max.looplength,
                         min.looplength=min.looplength,
-                        max.mismatch=max.mismatch)
+                        max.mismatch=max.mismatch,
+                        allow.wobble=allow.wobble)
     }
 )
 
@@ -133,11 +138,11 @@ setMethod("findPalindromes", "MaskedXString",
 ### The palindromeArmLength() generic and methods
 ###
 
-.palindrome_arm_length <- function(x, max.mismatch, L2R_lkup)
+.palindrome_arm_length <- function(x, max.mismatch, allow.wobble, L2R_lkup)
 {
     max.mismatch <- normargMaxMismatch(max.mismatch)
     armlength <- .Call2("palindrome_arm_length",
-                        x, max.mismatch, L2R_lkup,
+                        x, max.mismatch, allow.wobble, L2R_lkup,
                         PACKAGE="Biostrings")
     if (armlength == 0L)
         stop("'x' is not a palindrome (no arms found)")
@@ -145,37 +150,37 @@ setMethod("findPalindromes", "MaskedXString",
 }
 
 setGeneric("palindromeArmLength", signature="x",
-    function(x, max.mismatch=0) standardGeneric("palindromeArmLength")
+    function(x, max.mismatch=0, allow.wobble=FALSE) standardGeneric("palindromeArmLength")
 )
 
 setMethod("palindromeArmLength", "XString",
-    function(x, max.mismatch=0) .palindrome_arm_length(x, max.mismatch, NULL)
+    function(x, max.mismatch=0, allow.wobble=FALSE) .palindrome_arm_length(x, max.mismatch, allow.wobble, NULL)
 )
 
 setMethod("palindromeArmLength", "DNAString",
-    function(x, max.mismatch=0)
+    function(x, max.mismatch=0, allow.wobble=FALSE)
     {
         L2R_lkup <- .get_DNAorRNA_palindrome_L2R_lkup()
-        .palindrome_arm_length(x, max.mismatch, L2R_lkup)
+        .palindrome_arm_length(x, max.mismatch, allow.wobble, L2R_lkup)
     }
 )
 
 setMethod("palindromeArmLength", "RNAString",
-    function(x, max.mismatch=0)
+    function(x, max.mismatch=0, allow.wobble=FALSE)
     {
         L2R_lkup <- .get_DNAorRNA_palindrome_L2R_lkup()
-        .palindrome_arm_length(x, max.mismatch, L2R_lkup)
+        .palindrome_arm_length(x, max.mismatch, allow.wobble, L2R_lkup)
     }
 )
 
 setMethod("palindromeArmLength", "XStringViews",
-    function(x, max.mismatch=0)
+    function(x, max.mismatch=0, allow.wobble=FALSE)
     {
         if (length(x) == 0)
             return(integer(0))
         sapply(seq_len(length(x)),
                function(i)
-                   palindromeArmLength(x[[i]], max.mismatch=max.mismatch))
+                   palindromeArmLength(x[[i]], max.mismatch=max.mismatch, allow.wobble=allow.wobble))
     }
 )
 
@@ -185,46 +190,46 @@ setMethod("palindromeArmLength", "XStringViews",
 ###
 
 setGeneric("palindromeLeftArm", signature="x",
-    function(x, max.mismatch=0)
+    function(x, max.mismatch=0, allow.wobble=FALSE)
         standardGeneric("palindromeLeftArm")
 )
 
 setGeneric("palindromeRightArm", signature="x",
-    function(x, max.mismatch=0)
+    function(x, max.mismatch=0, allow.wobble=FALSE)
         standardGeneric("palindromeRightArm")
 )
 
 setMethod("palindromeLeftArm", "XString",
-    function(x, max.mismatch=0)
+    function(x, max.mismatch=0, allow.wobble=FALSE)
         subseq(x,
             start=1L,
-            end=palindromeArmLength(x, max.mismatch=max.mismatch)
+            end=palindromeArmLength(x, max.mismatch=max.mismatch, allow.wobble=allow.wobble)
         )
 )
 
 setMethod("palindromeRightArm", "XString",
-    function(x, max.mismatch=0)
+    function(x, max.mismatch=0, allow.wobble=FALSE)
     {
         start <- nchar(x) -
-                 palindromeArmLength(x, max.mismatch=max.mismatch) +
+                 palindromeArmLength(x, max.mismatch=max.mismatch, allow.wobble=allow.wobble) +
                  1L
         subseq(x, start=start, end=nchar(x))
     }
 )
 
 setMethod("palindromeLeftArm", "XStringViews",
-    function(x, max.mismatch=0)
+    function(x, max.mismatch=0, allow.wobble=FALSE)
     {
         ans_start <- start(x)
-        ans_width <- palindromeArmLength(x, max.mismatch=max.mismatch)
+        ans_width <- palindromeArmLength(x, max.mismatch=max.mismatch, allow.wobble=allow.wobble)
         unsafe.newXStringViews(subject(x), ans_start, ans_width)
     }
 )
 
 setMethod("palindromeRightArm", "XStringViews",
-    function(x, max.mismatch=0)
+    function(x, max.mismatch=0, allow.wobble=FALSE)
     {
-        ans_width <- palindromeArmLength(x, max.mismatch=max.mismatch)
+        ans_width <- palindromeArmLength(x, max.mismatch=max.mismatch, allow.wobble=allow.wobble)
         ans_start <- end(x) - ans_width + 1L
         unsafe.newXStringViews(subject(x), ans_start, ans_width)
     }

--- a/R/findPalindromes.R
+++ b/R/findPalindromes.R
@@ -42,7 +42,7 @@
         stop("'min.looplength' must be a non-negative integer")
     if (!is.logical(allow.wobble))
         stop("'allow.wobble' must be a logical")
-    if (allow.wobble && !is.null(L2R_lkup))
+    if (allow.wobble && is.null(L2R_lkup))
     	    stop("subject must be DNA or RNA if 'allow.wobble' is TRUE")
     ## check max.mismatch
     max.mismatch <- normargMaxMismatch(max.mismatch)

--- a/R/findPalindromes.R
+++ b/R/findPalindromes.R
@@ -148,9 +148,9 @@ setMethod("findPalindromes", "MaskedXString",
         stop("x must be DNA or RNA if 'allow.wobble' is TRUE")
 	
     max.mismatch <- normargMaxMismatch(max.mismatch)
-    armlength <- .Call2("palindrome_arm_length",
-                        x, max.mismatch, allow.wobble, L2R_lkup,
-                        PACKAGE="Biostrings")
+    .Call2("palindrome_arm_length",
+           x, max.mismatch, allow.wobble, L2R_lkup,
+           PACKAGE="Biostrings")
 }
 
 setGeneric("palindromeArmLength", signature="x",
@@ -158,13 +158,18 @@ setGeneric("palindromeArmLength", signature="x",
 )
 
 setMethod("palindromeArmLength", "XString",
-    function(x, max.mismatch=0, allow.wobble=FALSE) .palindrome_arm_length(x, max.mismatch, allow.wobble, NULL)
+    function(x, max.mismatch=0, allow.wobble=FALSE)
+    {
+    	    x <- as(x, "XStringSet")
+        .palindrome_arm_length(x, max.mismatch, allow.wobble, NULL)
+    }
 )
 
 setMethod("palindromeArmLength", "DNAString",
     function(x, max.mismatch=0, allow.wobble=FALSE)
     {
         L2R_lkup <- .get_DNAorRNA_palindrome_L2R_lkup()
+        x <- as(x, "DNAStringSet")
         .palindrome_arm_length(x, max.mismatch, allow.wobble, L2R_lkup)
     }
 )
@@ -173,6 +178,7 @@ setMethod("palindromeArmLength", "RNAString",
     function(x, max.mismatch=0, allow.wobble=FALSE)
     {
         L2R_lkup <- .get_DNAorRNA_palindrome_L2R_lkup()
+        x <- as(x, "RNAStringSet")
         .palindrome_arm_length(x, max.mismatch, allow.wobble, L2R_lkup)
     }
 )

--- a/inst/unitTests/test_findPalindromes.R
+++ b/inst/unitTests/test_findPalindromes.R
@@ -16,6 +16,10 @@ test_findPalindromes_on_non_nucleotide_sequence <- function()
     text3 <- BString("AATAAACTNTCAAATYCCY")
     current <- findPalindromes(text3, min.armlength=2)
     checkIdentical(IRanges(c(1, 3, 16), c(5, 15, 19)), ranges(current))
+    
+    text4 <- BString("i45hgfe7d321c3b4a56789uvwWVU98765A4B3C123D7EFGH54I")
+    current <- findPalindromes(text4, min.armlength = 5, max.looplength = length(text4), max.mismatch = 3)
+    checkIdentical(IRanges(c(18, 16, 14, 10, 8, 7), c(33, 35, 37, 41, 43, 44)), ranges(current))
 }
 
 test_findPalindromes_on_nucleotide_sequence <- function()

--- a/man/findPalindromes.Rd
+++ b/man/findPalindromes.Rd
@@ -12,6 +12,7 @@
 \alias{palindromeArmLength,DNAString-method}
 \alias{palindromeArmLength,RNAString-method}
 \alias{palindromeArmLength,XStringViews-method}
+\alias{palindromeArmLength,XStringSet-method}
 
 \alias{palindromeLeftArm}
 \alias{palindromeRightArm}
@@ -66,8 +67,8 @@ palindromeRightArm(x, max.mismatch=0, allow.wobble=FALSE)
     the palindromes to search for.
   }
   \item{allow.wobble}{
-    Logical indicating whether wobble base pairs should be treated as
-    mismatches (the default) or matches.
+    Logical indicating whether wobble base pairs (G/U or G/T base pairings)
+    should be treated as mismatches (the default) or matches.
   }
   \item{x}{
     An \link{XString} object containing a 2-arm palindrome, or an
@@ -160,6 +161,12 @@ findPalindromes(RNAString(x3))
 ## Note that palindromes can be nested:
 x4 <- DNAString("ACGTTNAACGTCCAAAATTTTCCACGTTNAACGT")
 findPalindromes(x4, max.looplength=19)
+
+## Treat wobble base pairings as matches:
+x5 <- RNAString("AUGUCUNNNNAGGCGU")
+findPalindromes(x5, min.looplength=4, max.looplength=4)
+findPalindromes(x5, max.mismatch=2, min.looplength=4, max.looplength=4)
+findPalindromes(x5, allow.wobble=TRUE, min.looplength=4, max.looplength=4)
 
 ## A real use case:
 library(BSgenome.Dmelanogaster.UCSC.dm3)

--- a/man/findPalindromes.Rd
+++ b/man/findPalindromes.Rd
@@ -34,11 +34,12 @@
 
 \usage{
 findPalindromes(subject, min.armlength=4,
-                max.looplength=1, min.looplength=0, max.mismatch=0)
+                max.looplength=1, min.looplength=0, max.mismatch=0,
+                allow.wobble=FALSE)
 
-palindromeArmLength(x, max.mismatch=0)
-palindromeLeftArm(x, max.mismatch=0)
-palindromeRightArm(x, max.mismatch=0)
+palindromeArmLength(x, max.mismatch=0, allow.wobble=FALSE)
+palindromeLeftArm(x, max.mismatch=0, allow.wobble=FALSE)
+palindromeRightArm(x, max.mismatch=0, allow.wobble=FALSE)
 }
 
 \arguments{
@@ -63,6 +64,10 @@ palindromeRightArm(x, max.mismatch=0)
   \item{max.mismatch}{
     The maximum number of mismatching letters allowed between the 2 arms of
     the palindromes to search for.
+  }
+  \item{allow.wobble}{
+    Logical indicating whether wobble base pairs should be treated as
+    mismatches (the default) or matches.
   }
   \item{x}{
     An \link{XString} object containing a 2-arm palindrome, or an

--- a/src/Biostrings.h
+++ b/src/Biostrings.h
@@ -740,6 +740,8 @@ SEXP find_palindromes(
 
 SEXP palindrome_arm_length(
 	SEXP x,
+	SEXP begin,
+	SEXP end,
 	SEXP max_mismatch,
 	SEXP allow_wobble,
 	SEXP L2R_lkup

--- a/src/Biostrings.h
+++ b/src/Biostrings.h
@@ -733,12 +733,15 @@ SEXP find_palindromes(
 	SEXP min_armlength,
 	SEXP max_looplength,
 	SEXP max_mismatch,
+	SEXP min_looplength,
+	SEXP allow_wobble,
 	SEXP L2R_lkup
 );
 
 SEXP palindrome_arm_length(
 	SEXP x,
 	SEXP max_mismatch,
+	SEXP allow_wobble,
 	SEXP L2R_lkup
 );
 

--- a/src/Biostrings.h
+++ b/src/Biostrings.h
@@ -740,8 +740,6 @@ SEXP find_palindromes(
 
 SEXP palindrome_arm_length(
 	SEXP x,
-	SEXP begin,
-	SEXP end,
 	SEXP max_mismatch,
 	SEXP allow_wobble,
 	SEXP L2R_lkup

--- a/src/R_init_Biostrings.c
+++ b/src/R_init_Biostrings.c
@@ -106,7 +106,7 @@ static const R_CallMethodDef callMethods[] = {
 
 /* find_palindromes.c */
 	CALLMETHOD_DEF(find_palindromes, 7),
-	CALLMETHOD_DEF(palindrome_arm_length, 4),
+	CALLMETHOD_DEF(palindrome_arm_length, 6),
 
 /* match_pdict_Twobit.c */
 	CALLMETHOD_DEF(build_Twobit, 3),

--- a/src/R_init_Biostrings.c
+++ b/src/R_init_Biostrings.c
@@ -105,8 +105,8 @@ static const R_CallMethodDef callMethods[] = {
 	CALLMETHOD_DEF(XStringViews_match_PWM, 7),
 
 /* find_palindromes.c */
-	CALLMETHOD_DEF(find_palindromes, 5),
-	CALLMETHOD_DEF(palindrome_arm_length, 3),
+	CALLMETHOD_DEF(find_palindromes, 7),
+	CALLMETHOD_DEF(palindrome_arm_length, 4),
 
 /* match_pdict_Twobit.c */
 	CALLMETHOD_DEF(build_Twobit, 3),

--- a/src/R_init_Biostrings.c
+++ b/src/R_init_Biostrings.c
@@ -106,7 +106,7 @@ static const R_CallMethodDef callMethods[] = {
 
 /* find_palindromes.c */
 	CALLMETHOD_DEF(find_palindromes, 7),
-	CALLMETHOD_DEF(palindrome_arm_length, 6),
+	CALLMETHOD_DEF(palindrome_arm_length, 4),
 
 /* match_pdict_Twobit.c */
 	CALLMETHOD_DEF(build_Twobit, 3),

--- a/src/find_palindromes.c
+++ b/src/find_palindromes.c
@@ -18,8 +18,8 @@ static int is_match(char c1, char c2, int allow_wobble1,
 	}
 	if (allow_wobble1) {
 		return c1 == c2 ||
-			(c1==2 && c2==8) || // G and T/U
-			(c1==1 && c2==4); // T/U and G
+			(c1 == 2 && c2 == 8) || // G and T/U
+			(c1 == 1 && c2 == 4); // T/U and G
 	} else {
 		return c1 == c2;
 	}
@@ -49,8 +49,7 @@ static void get_find_palindromes_at(const char *x, int x_len,
 				arms[count] = arm_len;
 				count++;
 			}
-			if (ismatch ||
-			    nmis++ < max_nmis) {
+			if (ismatch || nmis++ < max_nmis) {
 				arm_len++;
 				goto next;
 			}
@@ -134,17 +133,13 @@ SEXP find_palindromes(SEXP x, SEXP min_armlength, SEXP max_looplength,
 }
 
 /* --- .Call ENTRY POINT --- */
-SEXP palindrome_arm_length(SEXP x, SEXP begin, SEXP end, SEXP max_mismatch, SEXP allow_wobble, SEXP L2R_lkup)
+SEXP palindrome_arm_length(SEXP x, SEXP max_mismatch, SEXP allow_wobble, SEXP L2R_lkup)
 {
-	Chars_holder x_holder;
-	int x_len, max_nmis, lkup_len, allow_wobble1;
+	XStringSet_holder x_holder = _hold_XStringSet(x);
+	int x_len = _get_XStringSet_length(x);
+	int max_nmis, lkup_len, allow_wobble1;
 	const int *lkup;
-	int *b = INTEGER(begin);
-	int *e = INTEGER(end);
-	int l = length(begin);
 
-	x_holder = hold_XRaw(x);
-	x_len = x_holder.length;
 	max_nmis = INTEGER(max_mismatch)[0];
 	allow_wobble1 = INTEGER(allow_wobble)[0];
 	if (L2R_lkup == R_NilValue) {
@@ -156,12 +151,14 @@ SEXP palindrome_arm_length(SEXP x, SEXP begin, SEXP end, SEXP max_mismatch, SEXP
 	}
 	
 	SEXP ans;
-	PROTECT(ans = allocVector(INTSXP, l));
+	PROTECT(ans = NEW_INTEGER(x_len));
 	int *rans = INTEGER(ans);
 	
-	for (int i = 0; i < l; i++)
-		rans[i] = get_palindrome_arm_length(x_holder.ptr + b[i] - 1,
-			e[i] - b[i] + 1, max_nmis, allow_wobble1, lkup, lkup_len);
+	for (int i = 0; i < x_len; i++) {
+		Chars_holder x_elt_holder = _get_elt_from_XStringSet_holder(&x_holder, i);
+		rans[i] = get_palindrome_arm_length(x_elt_holder.ptr, x_elt_holder.length,
+											max_nmis, allow_wobble1, lkup, lkup_len);
+	}
 	
 	UNPROTECT(1);
 	

--- a/src/find_palindromes.c
+++ b/src/find_palindromes.c
@@ -5,7 +5,8 @@
 #include <stdio.h>
 
 
-static int is_match(char c1, char c2, const int *lkup, int lkup_len)
+static int is_match(char c1, char c2, int allow_wobble1,
+	const int *lkup, int lkup_len)
 {
 	int key, val;
 
@@ -15,12 +16,18 @@ static int is_match(char c1, char c2, const int *lkup, int lkup_len)
 			return 0;
 		c1 = (char) val;
 	}
-	return c1 == c2;
+	if (allow_wobble1) {
+		return c1 == c2 ||
+			(c1==2 && c2==8) || // G and T/U
+			(c1==1 && c2==4); // T/U and G
+	} else {
+		return c1 == c2;
+	}
 }
 
 static void get_find_palindromes_at(const char *x, int x_len,
 	int i1, int i2, int max_loop_len1, int min_arm_len, int max_nmis,
-	const int *lkup, int lkup_len)
+	int allow_wobble1, const int *lkup, int lkup_len)
 {
 	int arm_len, valid_indices;
 	char c1, c2;
@@ -32,7 +39,7 @@ static void get_find_palindromes_at(const char *x, int x_len,
 		if (valid_indices) {
 			c1 = x[i1];
 			c2 = x[i2];
-			if (is_match(c1, c2, lkup, lkup_len) ||
+			if (is_match(c1, c2, allow_wobble1, lkup, lkup_len) ||
 			    max_nmis-- > 0) {
 				arm_len++;
 				goto next;
@@ -49,7 +56,7 @@ static void get_find_palindromes_at(const char *x, int x_len,
 }
 
 static int get_palindrome_arm_length(const char *x, int x_len, int max_nmis,
-	const int *lkup, int lkup_len)
+	int allow_wobble1, const int *lkup, int lkup_len)
 {
 	int i1, i2;
 	char c1, c2;
@@ -57,7 +64,7 @@ static int get_palindrome_arm_length(const char *x, int x_len, int max_nmis,
 	for (i1 = 0, i2 = x_len - 1; i1 < i2; i1++, i2--) {
 		c1 = x[i1];
 		c2 = x[i2];
-		if (!(is_match(c1, c2, lkup, lkup_len) ||
+		if (!(is_match(c1, c2, allow_wobble1, lkup, lkup_len) ||
 		      max_nmis-- > 0))
 			break;
 	}
@@ -66,10 +73,12 @@ static int get_palindrome_arm_length(const char *x, int x_len, int max_nmis,
 
 /* --- .Call ENTRY POINT --- */
 SEXP find_palindromes(SEXP x, SEXP min_armlength, SEXP max_looplength,
-		      SEXP max_mismatch, SEXP L2R_lkup)
+		      SEXP max_mismatch, SEXP min_looplength, SEXP allow_wobble,
+		      SEXP L2R_lkup)
 {
 	Chars_holder x_holder;
-	int x_len, min_arm_len, max_loop_len1, max_nmis, lkup_len, n;
+	int x_len, min_arm_len, max_loop_len1, max_nmis, lkup_len, n,
+		min_loop_len1, min_loop_len2, allow_wobble1;
 	const int *lkup;
 
 	x_holder = hold_XRaw(x);
@@ -77,6 +86,10 @@ SEXP find_palindromes(SEXP x, SEXP min_armlength, SEXP max_looplength,
 	min_arm_len = INTEGER(min_armlength)[0];
 	max_loop_len1 = INTEGER(max_looplength)[0] + 1;
 	max_nmis = INTEGER(max_mismatch)[0];
+	min_loop_len1 = INTEGER(min_looplength)[0];
+	min_loop_len2 = (min_loop_len1 + 1)/2; // 0 1 1 2 2 ...
+	min_loop_len1 /= 2; // 0 0 1 1 2 2 ...
+	allow_wobble1 = INTEGER(allow_wobble)[0];
 	if (L2R_lkup == R_NilValue) {
 		lkup = NULL;
 		lkup_len = 0;
@@ -87,27 +100,28 @@ SEXP find_palindromes(SEXP x, SEXP min_armlength, SEXP max_looplength,
 	_init_match_reporting("MATCHES_AS_RANGES", 1);
 	for (n = 0; n < x_len; n++) {
 		/* Find palindromes centered on n. */
-		get_find_palindromes_at(x_holder.ptr, x_len, n - 1, n + 1,
-					max_loop_len1, min_arm_len, max_nmis,
-					lkup, lkup_len);
+		get_find_palindromes_at(x_holder.ptr, x_len, n - 1 - min_loop_len1,
+					n + 1 + min_loop_len1, max_loop_len1, min_arm_len,
+					max_nmis, allow_wobble1, lkup, lkup_len);
 		/* Find palindromes centered on n + 0.5. */
-		get_find_palindromes_at(x_holder.ptr, x_len, n, n + 1,
-					max_loop_len1, min_arm_len, max_nmis,
-					lkup, lkup_len);
+		get_find_palindromes_at(x_holder.ptr, x_len, n - min_loop_len2,
+					n + 1 + min_loop_len2, max_loop_len1, min_arm_len,
+					max_nmis, allow_wobble1, lkup, lkup_len);
 	}
 	return _reported_matches_asSEXP();
 }
 
 /* --- .Call ENTRY POINT --- */
-SEXP palindrome_arm_length(SEXP x, SEXP max_mismatch, SEXP L2R_lkup)
+SEXP palindrome_arm_length(SEXP x, SEXP max_mismatch, SEXP allow_wobble, SEXP L2R_lkup)
 {
 	Chars_holder x_holder;
-	int x_len, max_nmis, lkup_len, arm_len;
+	int x_len, max_nmis, lkup_len, arm_len, allow_wobble1;
 	const int *lkup;
 
 	x_holder = hold_XRaw(x);
 	x_len = x_holder.length;
 	max_nmis = INTEGER(max_mismatch)[0];
+	allow_wobble1 = INTEGER(allow_wobble)[0];
 	if (L2R_lkup == R_NilValue) {
 		lkup = NULL;
 		lkup_len = 0;
@@ -116,7 +130,7 @@ SEXP palindrome_arm_length(SEXP x, SEXP max_mismatch, SEXP L2R_lkup)
 		lkup_len = LENGTH(L2R_lkup);
 	}
 	arm_len = get_palindrome_arm_length(x_holder.ptr, x_len, max_nmis,
-					    lkup, lkup_len);
+					    allow_wobble1, lkup, lkup_len);
 	return ScalarInteger(arm_len);
 }
 

--- a/src/find_palindromes.c
+++ b/src/find_palindromes.c
@@ -134,11 +134,14 @@ SEXP find_palindromes(SEXP x, SEXP min_armlength, SEXP max_looplength,
 }
 
 /* --- .Call ENTRY POINT --- */
-SEXP palindrome_arm_length(SEXP x, SEXP max_mismatch, SEXP allow_wobble, SEXP L2R_lkup)
+SEXP palindrome_arm_length(SEXP x, SEXP begin, SEXP end, SEXP max_mismatch, SEXP allow_wobble, SEXP L2R_lkup)
 {
 	Chars_holder x_holder;
-	int x_len, max_nmis, lkup_len, arm_len, allow_wobble1;
+	int x_len, max_nmis, lkup_len, allow_wobble1;
 	const int *lkup;
+	int *b = INTEGER(begin);
+	int *e = INTEGER(end);
+	int l = length(begin);
 
 	x_holder = hold_XRaw(x);
 	x_len = x_holder.length;
@@ -151,8 +154,17 @@ SEXP palindrome_arm_length(SEXP x, SEXP max_mismatch, SEXP allow_wobble, SEXP L2
 		lkup = INTEGER(L2R_lkup);
 		lkup_len = LENGTH(L2R_lkup);
 	}
-	arm_len = get_palindrome_arm_length(x_holder.ptr, x_len, max_nmis,
-					    allow_wobble1, lkup, lkup_len);
-	return ScalarInteger(arm_len);
+	
+	SEXP ans;
+	PROTECT(ans = allocVector(INTSXP, l));
+	int *rans = INTEGER(ans);
+	
+	for (int i = 0; i < l; i++)
+		rans[i] = get_palindrome_arm_length(x_holder.ptr + b[i] - 1,
+			e[i] - b[i] + 1, max_nmis, allow_wobble1, lkup, lkup_len);
+	
+	UNPROTECT(1);
+	
+	return ans;
 }
 


### PR DESCRIPTION
The attached code makes the following modifications:

(1)  min.looplength is now implemented.  Previously specification of a non-zero value would throw an error saying "will be implemented very soon!".  This has been the case for many years.

(2)  I added a new argument to allow.wobble that will accept G/T and T/G mismatches as matches.  This makes the function more practical for finding hairpins since wobble bases are frequent in real palindromes.  The default is FALSE to keep the code backwards compatible.