### PR TITLE
add option to make asymmetric nuc substitution matrix

### DIFF
--- a/R/pairwiseAlignment.R
+++ b/R/pairwiseAlignment.R
@@ -13,24 +13,40 @@
 ### -------------------------------------------------------------------------
 
 
-nucleotideSubstitutionMatrix <- function(match = 1, mismatch = 0, baseOnly = FALSE, type = "DNA")
-{
+nucleotideSubstitutionMatrix <-
+function(match = 1, mismatch = 0, baseOnly = FALSE, type = "DNA", symmetric = TRUE) {
   "%safemult%" <- function(x, y) ifelse(is.infinite(x) & y == 0, 0, x * y)
   type <- match.arg(type, c("DNA", "RNA"))
-  if (!isSingleNumber(match) || !isSingleNumber(mismatch))
+  if (!isSingleNumber(match) || !isSingleNumber(mismatch)) {
     stop("'match' and 'mismatch' must be non-missing numbers")
-  if (baseOnly)
+  }
+  if (baseOnly) {
     letters <- IUPAC_CODE_MAP[DNA_BASES]
-  else
+  }
+  else {
     letters <- IUPAC_CODE_MAP
-  if (type == "RNA")
+  }
+  if (type == "RNA") {
     names(letters) <- chartr("T", "U", names(letters))
+  }
   nLetters <- length(letters)
   splitLetters <- strsplit(letters,split="")
   submat <- matrix(0, nrow = nLetters, ncol = nLetters, dimnames = list(names(letters), names(letters)))
-  for(i in 1:nLetters)
-    for(j in i:nLetters)
-      submat[i,j] <- submat[j,i] <- mean(outer(splitLetters[[i]], splitLetters[[j]], "=="))
+  if (symmetric) {
+    for (i in 1:nLetters) {
+      for (j in i:nLetters) {
+        submat[i,j] <- submat[j,i] <- mean(outer(splitLetters[[i]], splitLetters[[j]], "=="))
+      }
+    }
+  }
+  else {
+    for (i in 1:nLetters) {
+      for (j in i:nLetters) {
+        submat[i,j] <- mean(outer(splitLetters[[i]], splitLetters[[j]], "%in%"))
+        submat[j,i] <- mean(outer(splitLetters[[j]], splitLetters[[i]], "%in%"))
+      }
+    }
+  }
   abs(match) * submat - abs(mismatch) %safemult% (1 - submat)
 }
 

--- a/man/substitution_matrices.Rd
+++ b/man/substitution_matrices.Rd
@@ -140,16 +140,26 @@ K. Malde, The effect of sequence quality on sequence alignment, Bioinformatics, 
                     substitutionMatrix = nucleotideSubstitutionMatrix(0, -1, TRUE),
                     gapOpening = 0, gapExtension = 1)
 
-  ## Align a sequence to a consensus using an asymmetric substitution matrix.
+  ## Align sequences using an asymmetric substitution matrix.
   ## The asymmetry of the matrix means that the query sequence
   ## is not penalized for ambiguous bases in the subject / consensus sequence.
+  ansm <- nucleotideSubstitutionMatrix(symmetric = FALSE)
+  ansm["M", c("A","C","G","T")]
+  #  A   C   G   T 
+  # 0.5 0.5 0.0 0.0 
+  ansm[c("A","C","G","T"), "M"]
+  # A C G T 
+  # 1 1 0 0 
+  ansm["M", "H"]
+  # 1
+  ansm["H", "M"]
+  # 0.6666667
+
   ## Due to this asymmetry, the order of the sequences is important.
   pairwiseAlignment(s1, s3,
-                    substitutionMatrix = nucleotideSubstitutionMatrix(symmetric = FALSE))
+                    substitutionMatrix = ansm)
   pairwiseAlignment(s3, s1,
-                    substitutionMatrix = nucleotideSubstitutionMatrix(symmetric = FALSE))
-
-  
+                    substitutionMatrix = ansm)
 
   ## Examine quality-based match and mismatch bit scores for DNA/RNA
   ## strings in pairwiseAlignment.

--- a/man/substitution_matrices.Rd
+++ b/man/substitution_matrices.Rd
@@ -34,7 +34,7 @@ data(PAM40)
 data(PAM70)
 data(PAM120)
 data(PAM250)
-nucleotideSubstitutionMatrix(match = 1, mismatch = 0, baseOnly = FALSE, type = "DNA")
+nucleotideSubstitutionMatrix(match = 1, mismatch = 0, baseOnly = FALSE, type = "DNA", symmetric = TRUE)
 qualitySubstitutionMatrices(fuzzyMatch = c(0, 1), alphabetLength = 4L, qualityClass = "PhredQuality", bitScale = 1)
 errorSubstitutionMatrices(errorProbability, fuzzyMatch = c(0, 1), alphabetLength = 4L, bitScale = 1)
 }
@@ -45,6 +45,8 @@ errorSubstitutionMatrices(errorProbability, fuzzyMatch = c(0, 1), alphabetLength
   \item{baseOnly}{\code{TRUE} or \code{FALSE}. If \code{TRUE}, only
     uses the letters in the "base" alphabet i.e. "A", "C", "G", "T".}
   \item{type}{either "DNA" or "RNA".}
+  \item{symmetric}{\code{TRUE} or \code{FALSE}. Default is \code{TRUE}. 
+    If \code{FALSE}, the resulting matrix will be asymmetric.}
   \item{fuzzyMatch}{a named or unnamed numeric vector representing the base
     match probability.}
   \item{errorProbability}{a named or unnamed numeric vector representing the error
@@ -112,7 +114,8 @@ errorSubstitutionMatrices(errorProbability, fuzzyMatch = c(0, 1), alphabetLength
 K. Malde, The effect of sequence quality on sequence alignment, Bioinformatics, Feb 23, 2008.
 }
 
-\author{H. Pagès and P. Aboyoun}
+\author{H. Pagès and P. Aboyoun, with contribution from Albert Vill (support
+        for asymmetric matrices in \code{nucleotideSubstitutionMatrix()})}
 
 \seealso{
   \code{\link{pairwiseAlignment}},
@@ -129,11 +132,24 @@ K. Malde, The effect of sequence quality on sequence alignment, Bioinformatics, 
     DNAString("ACTTCACCAGCTCCCTGGCGGTAAGTTGATCAAAGGAAACGCAAAGTTTTCAAG")
   s2 <-
     DNAString("GTTTCACTACTTCCTTTCGGGTAAGTAAATATATAAATATATAAAAATATAATTTTCATC")
+  s3 <-
+    DNAString("NCTTCRCCAGCTCCCTGGMGGTAAGTTGATCAAAGVAAACGCAAAGTTNTCAAG")
 
   ## Fit a global pairwise alignment using edit distance scoring
   pairwiseAlignment(s1, s2,
                     substitutionMatrix = nucleotideSubstitutionMatrix(0, -1, TRUE),
                     gapOpening = 0, gapExtension = 1)
+
+  ## Align a sequence to a consensus using an asymmetric substitution matrix.
+  ## The asymmetry of the matrix means that the query sequence
+  ## is not penalized for ambiguous bases in the subject / consensus sequence.
+  ## Due to this asymmetry, the order of the sequences is important.
+  pairwiseAlignment(s1, s3,
+                    substitutionMatrix = nucleotideSubstitutionMatrix(symmetric = FALSE))
+  pairwiseAlignment(s3, s1,
+                    substitutionMatrix = nucleotideSubstitutionMatrix(symmetric = FALSE))
+
+  
 
   ## Examine quality-based match and mismatch bit scores for DNA/RNA
   ## strings in pairwiseAlignment.


### PR DESCRIPTION
Edited `nucleotideSubstitutionMatrix` function in `pairwiseAlignment.R` to include an option to generate an asymmetric nucleotide substitution matrix. This is useful when you don't want to penalize a query sequence that is aligned to a subject / consensus with ambiguous bases. 

- For context, see https://github.com/Bioconductor/Biostrings/issues/3#issuecomment-358849578. 
- For explanation of implementation, see https://bioinformatics.stackexchange.com/a/19612/3967.