### PR TITLE
feat: Colored characters for AAStrings

### DIFF
--- a/R/coloring.R
+++ b/R/coloring.R
@@ -57,62 +57,64 @@ make_DNA_AND_RNA_COLORED_LETTERS <- function()
         names(ans) <- x_names
     ans
 }
+
 ### Return a named character vector where all the names are single letters.
 ## Colors amino acids by similarity
 ## Colors groupins by 
 ##  https://www.jalview.org/help/html/colourSchemes/zappo.html
+### Called in .onLoad() to initialize AA_COLORED_LETTERS.
 make_AA_COLORED_LETTERS <- function(x){
-  whiter <- make_style(rgb(1, 1, 1))
-  dark_grey_bg <- make_style(rgb(0.5,0.5,0.5), bg=TRUE)
+    whiter <- make_style(rgb(1, 1, 1))
+    dark_grey_bg <- make_style(rgb(0.5,0.5,0.5), bg=TRUE)
+    
+    ## All the IUPAC ambiguity letters minus X.
+    dark_grey_bg_letters <- c("U","O","B","J","Z")
+                               
+    cp <- c("#fbf8cc", "#ffcfd2", "#cfbaf0",
+            "#a3c4f3", "#8eecf5", "#b9fbc0", "#f1c0e8")
   
-  ## All the IUPAC ambiguity letters minus X.
-  dark_grey_bg_letters <- c("U","O","B","J","Z")
-                             
-  cp <- c("#fbf8cc", "#ffcfd2", "#cfbaf0",
-          "#a3c4f3", "#8eecf5", "#b9fbc0", "#f1c0e8")
-  
-  c(
-    # Cysteine
-    C=make_style(cp[1], bg=TRUE)(black("C")),
-    
-    # Aliphatic/hydrophobic
-    A=make_style(cp[2], bg=TRUE)(black("A")),
-    V=make_style(cp[2], bg=TRUE)(black("V")),
-    M=make_style(cp[2], bg=TRUE)(black("M")), 
-    L=make_style(cp[2], bg=TRUE)(black("L")), 
-    I=make_style(cp[2], bg=TRUE)(black("I")),
-    
-    # Conformationally Special
-    P=make_style(cp[3], bg=TRUE)(black("P")),
-    G=make_style(cp[3], bg=TRUE)(black("G")), 
-    
-    # Positive
-    K=make_style(cp[4], bg=TRUE)(black("K")),
-    R=make_style(cp[4], bg=TRUE)(black("R")),
-    H=make_style(cp[4], bg=TRUE)(black("H")),
-    
-    # Hydrophilic
-    N=make_style(cp[5], bg=TRUE)(black("N")),
-    T=make_style(cp[5], bg=TRUE)(black("T")),
-    Q=make_style(cp[5], bg=TRUE)(black("Q")),
-    S=make_style(cp[5], bg=TRUE)(black("S")),
-    
-    # Aromatic
-    F=make_style(cp[6], bg=TRUE)(black("F")),
-    Y=make_style(cp[6], bg=TRUE)(black("Y")),
-    W=make_style(cp[6], bg=TRUE)(black("W")),
-    
-    # Negative
-    E=make_style(cp[7], bg=TRUE)(black("E")),
-    D=make_style(cp[7], bg=TRUE)(black("D")),
-    
-    # Ambiguity
-    setNames(sprintf(dark_grey_bg(whiter("%s")), dark_grey_bg_letters),
-             dark_grey_bg_letters),
-    
-    # Any code
-    X=make_style("grey", bg=TRUE)(whiter("X"))
-  )
+    c(
+        # Cysteine
+        C=make_style(cp[1], bg=TRUE)(black("C")),
+        
+        # Aliphatic/hydrophobic
+        A=make_style(cp[2], bg=TRUE)(black("A")),
+        V=make_style(cp[2], bg=TRUE)(black("V")),
+        M=make_style(cp[2], bg=TRUE)(black("M")), 
+        L=make_style(cp[2], bg=TRUE)(black("L")), 
+        I=make_style(cp[2], bg=TRUE)(black("I")),
+        
+        # Conformationally Special
+        P=make_style(cp[3], bg=TRUE)(black("P")),
+        G=make_style(cp[3], bg=TRUE)(black("G")), 
+        
+        # Positive
+        K=make_style(cp[4], bg=TRUE)(black("K")),
+        R=make_style(cp[4], bg=TRUE)(black("R")),
+        H=make_style(cp[4], bg=TRUE)(black("H")),
+        
+        # Hydrophilic
+        N=make_style(cp[5], bg=TRUE)(black("N")),
+        T=make_style(cp[5], bg=TRUE)(black("T")),
+        Q=make_style(cp[5], bg=TRUE)(black("Q")),
+        S=make_style(cp[5], bg=TRUE)(black("S")),
+        
+        # Aromatic
+        F=make_style(cp[6], bg=TRUE)(black("F")),
+        Y=make_style(cp[6], bg=TRUE)(black("Y")),
+        W=make_style(cp[6], bg=TRUE)(black("W")),
+        
+        # Negative
+        E=make_style(cp[7], bg=TRUE)(black("E")),
+        D=make_style(cp[7], bg=TRUE)(black("D")),
+        
+        # Ambiguity
+        setNames(sprintf(dark_grey_bg(whiter("%s")), dark_grey_bg_letters),
+                 dark_grey_bg_letters),
+        
+        # Any code
+        X=make_style("grey", bg=TRUE)(whiter("X"))
+    )
 }
 
 ### 'x' must be a character vector.
@@ -141,4 +143,3 @@ add_colors <- function(x) UseMethod("add_colors")
 add_colors.default <- identity
 add_colors.DNA <- add_colors.RNA <- .add_dna_and_rna_colors
 add_colors.AA <- .add_aa_colors
-

--- a/R/coloring.R
+++ b/R/coloring.R
@@ -66,52 +66,52 @@ make_DNA_AND_RNA_COLORED_LETTERS <- function()
 make_AA_COLORED_LETTERS <- function(x){
     whiter <- make_style(rgb(1, 1, 1))
     dark_grey_bg <- make_style(rgb(0.5,0.5,0.5), bg=TRUE)
-    
+
     ## All the IUPAC ambiguity letters minus X.
     dark_grey_bg_letters <- c("U","O","B","J","Z")
-                               
+
     cp <- c("#fbf8cc", "#ffcfd2", "#cfbaf0",
             "#a3c4f3", "#8eecf5", "#b9fbc0", "#f1c0e8")
-  
+
     c(
         # Cysteine
         C=make_style(cp[1], bg=TRUE)(black("C")),
-        
+
         # Aliphatic/hydrophobic
         A=make_style(cp[2], bg=TRUE)(black("A")),
         V=make_style(cp[2], bg=TRUE)(black("V")),
         M=make_style(cp[2], bg=TRUE)(black("M")), 
         L=make_style(cp[2], bg=TRUE)(black("L")), 
         I=make_style(cp[2], bg=TRUE)(black("I")),
-        
+
         # Conformationally Special
         P=make_style(cp[3], bg=TRUE)(black("P")),
         G=make_style(cp[3], bg=TRUE)(black("G")), 
-        
+
         # Positive
         K=make_style(cp[4], bg=TRUE)(black("K")),
         R=make_style(cp[4], bg=TRUE)(black("R")),
         H=make_style(cp[4], bg=TRUE)(black("H")),
-        
+
         # Hydrophilic
         N=make_style(cp[5], bg=TRUE)(black("N")),
         T=make_style(cp[5], bg=TRUE)(black("T")),
         Q=make_style(cp[5], bg=TRUE)(black("Q")),
         S=make_style(cp[5], bg=TRUE)(black("S")),
-        
+
         # Aromatic
         F=make_style(cp[6], bg=TRUE)(black("F")),
         Y=make_style(cp[6], bg=TRUE)(black("Y")),
         W=make_style(cp[6], bg=TRUE)(black("W")),
-        
+
         # Negative
         E=make_style(cp[7], bg=TRUE)(black("E")),
         D=make_style(cp[7], bg=TRUE)(black("D")),
-        
+
         # Ambiguity
         setNames(sprintf(dark_grey_bg(whiter("%s")), dark_grey_bg_letters),
                  dark_grey_bg_letters),
-        
+
         # Any code
         X=make_style("grey", bg=TRUE)(whiter("X"))
     )

--- a/R/coloring.R
+++ b/R/coloring.R
@@ -7,6 +7,7 @@
 
 ### Placeholder, initialized in .onLoad()
 DNA_AND_RNA_COLORED_LETTERS <- NULL
+AA_COLORED_LETTERS <- NULL
 
 ### Return a named character vector where all the names are single letters.
 ### Colors for A, C, G, and T were inspired by
@@ -56,8 +57,88 @@ make_DNA_AND_RNA_COLORED_LETTERS <- function()
         names(ans) <- x_names
     ans
 }
+### Return a named character vector where all the names are single letters.
+## Colors amino acids by similarity
+## Colors groupins by 
+##  https://www.jalview.org/help/html/colourSchemes/zappo.html
+make_AA_COLORED_LETTERS <- function(x){
+  whiter <- make_style(rgb(1, 1, 1))
+  dark_grey_bg <- make_style(rgb(0.5,0.5,0.5), bg=TRUE)
+  
+  ## All the IUPAC ambiguity letters minus X.
+  dark_grey_bg_letters <- c("U","O","B","J","Z")
+                             
+  cp <- c("#fbf8cc", "#ffcfd2", "#cfbaf0",
+          "#a3c4f3", "#8eecf5", "#b9fbc0", "#f1c0e8")
+  
+  c(
+    # Cysteine
+    C=make_style(cp[1], bg=TRUE)(black("C")),
+    
+    # Aliphatic/hydrophobic
+    A=make_style(cp[2], bg=TRUE)(black("A")),
+    V=make_style(cp[2], bg=TRUE)(black("V")),
+    M=make_style(cp[2], bg=TRUE)(black("M")), 
+    L=make_style(cp[2], bg=TRUE)(black("L")), 
+    I=make_style(cp[2], bg=TRUE)(black("I")),
+    
+    # Conformationally Special
+    P=make_style(cp[3], bg=TRUE)(black("P")),
+    G=make_style(cp[3], bg=TRUE)(black("G")), 
+    
+    # Positive
+    K=make_style(cp[4], bg=TRUE)(black("K")),
+    R=make_style(cp[4], bg=TRUE)(black("R")),
+    H=make_style(cp[4], bg=TRUE)(black("H")),
+    
+    # Hydrophilic
+    N=make_style(cp[5], bg=TRUE)(black("N")),
+    T=make_style(cp[5], bg=TRUE)(black("T")),
+    Q=make_style(cp[5], bg=TRUE)(black("Q")),
+    S=make_style(cp[5], bg=TRUE)(black("S")),
+    
+    # Aromatic
+    F=make_style(cp[6], bg=TRUE)(black("F")),
+    Y=make_style(cp[6], bg=TRUE)(black("Y")),
+    W=make_style(cp[6], bg=TRUE)(black("W")),
+    
+    # Negative
+    E=make_style(cp[7], bg=TRUE)(black("E")),
+    D=make_style(cp[7], bg=TRUE)(black("D")),
+    
+    # Ambiguity
+    setNames(sprintf(dark_grey_bg(whiter("%s")), dark_grey_bg_letters),
+             dark_grey_bg_letters),
+    
+    # Any code
+    X=make_style("grey", bg=TRUE)(whiter("X"))
+  )
+}
+
+### 'x' must be a character vector.
+.add_aa_colors <- function(x)
+{
+    if (!isTRUE(getOption("Biostrings.coloring", default=FALSE)))
+        return(x)
+    ans <- vapply(x,
+        function(xi) {
+            xi <- safeExplode(xi)
+            m <- match(xi, names(AA_COLORED_LETTERS))
+            match_idx <- which(!is.na(m))
+            xi[match_idx] <- AA_COLORED_LETTERS[m[match_idx]]
+            paste0(xi, collapse="")
+        },
+        character(1),
+        USE.NAMES=FALSE
+    )
+    x_names <- names(x)
+    if (!is.null(x_names))
+        names(ans) <- x_names
+    ans
+}
 
 add_colors <- function(x) UseMethod("add_colors")
 add_colors.default <- identity
 add_colors.DNA <- add_colors.RNA <- .add_dna_and_rna_colors
+add_colors.AA <- .add_aa_colors
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -21,4 +21,3 @@
 }
 
 .test <- function() BiocGenerics:::testPackage("Biostrings")
-

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,6 +9,7 @@
           RNA_STRING_CODEC@enc_lkup, RNA_STRING_CODEC@dec_lkup,
           PACKAGE=pkgname)
     DNA_AND_RNA_COLORED_LETTERS <<- make_DNA_AND_RNA_COLORED_LETTERS()
+    AA_COLORED_LETTERS <<- make_AA_COLORED_LETTERS()
     option_name <- "Biostrings.coloring"
     if (!(option_name %in% names(.Options)))
         options(setNames(list(TRUE), option_name))

--- a/man/AAString-class.Rd
+++ b/man/AAString-class.Rd
@@ -93,6 +93,12 @@ AA_PROTEINOGENIC  # first 22 letters only
   }
 }
 
+\section{Display}{
+  The letters in an AAString object are colored when 
+  displayed by the \code{show()} method. Set global option 
+  \code{Biostrings.coloring} to FALSE to turn off this coloring.
+}
+
 \author{H. Pagès}
 
 \seealso{

--- a/man/XStringSet-class.Rd
+++ b/man/XStringSet-class.Rd
@@ -313,9 +313,10 @@ AAStringSet(x=character(), start=NA, end=NA, width=NA, use.names=TRUE)
 }
 
 \section{Display}{
-  The letters in a DNAStringSet or RNAStringSet object are colored
-  when displayed by the \code{show()} method. Set global option
-  \code{Biostrings.coloring} to FALSE to turn off this coloring.
+  The letters in a DNAStringSet, RNAStringSet, or AAStringSet 
+  object are colored when displayed by the \code{show()} 
+  method. Set global option \code{Biostrings.coloring} to 
+  FALSE to turn off this coloring.
 }
 
 \author{H. Pagès}


### PR DESCRIPTION
Small PR, just adds colored characters for AAStrings. Using a full 20 color palette is possible, but the result is relatively messy--difficult to choose colors that are simultaneously discernable, preserve readability of the characters, and don't overwhelm users.

Compromise chosen was to color bases based on physiochemical properties: https://www.jalview.org/help/html/colourSchemes/zappo.html

Color scheme chosen was a 7 color pastel to reduce the loudness of the color set. Result seems to be fairly easy to read while still being discernable. Color set is not colorblind friendly.

I'm open to adapting the color scheme to something else, it's written to be simple to change. I'm also happy to add in additional documentation to `AAString-class.Rd` describing how the bases are colored.

All letters:
![Screen Shot 2023-03-27 at 13 16 25](https://user-images.githubusercontent.com/30053966/228018168-0fdb7254-d3cf-4cbc-8e8d-0d47e25df444.png)

Example of an alignment:
![Screen Shot 2023-03-27 at 13 16 17](https://user-images.githubusercontent.com/30053966/228018237-03d497eb-98e1-42b5-b17b-41c1fad65b86.png)

Example of random characters:
![Screen Shot 2023-03-27 at 13 16 33](https://user-images.githubusercontent.com/30053966/228018292-52200a23-d5fe-461b-bc9a-4235b67dd767.png)


