### PR TITLE
add BiocStyle to setup chunk for Biocpkg calls in vignette

### DIFF
--- a/vignettes/matchprobes.Rmd
+++ b/vignettes/matchprobes.Rmd
@@ -18,6 +18,10 @@ output:
 fig_caption: true
 ---
 
+```{r setup,include=FALSE}
+library(BiocStyle)
+```
+
 # Overview
 
 This document presents some basic and simple tools for dealing with the


### PR DESCRIPTION
`Biocpkg` is used in the vignette but `BiocStyle` is not loaded or referenced

RE: https://github.com/r-universe/bioconductor/actions/runs/7684142017/job/20940280799