### PR TITLE
fix: Issue #106

### DIFF
--- a/R/QualityScaledXStringSet.R
+++ b/R/QualityScaledXStringSet.R
@@ -186,6 +186,12 @@ readQualityScaledDNAStringSet <- function(filepath,
                           nrec, skip, seek.first.rec,
                           use.names, with.qualities=TRUE)
     qualities <- mcols(x)[ , "qualities"]
+    ## Clear out the qualities parameter from the SS, since it gets passed 
+    ## into the QSSS constructor via quals anyway
+    ## (otherwise we get a warning that doesn't make sense)
+    mcols(x)[,"qualities"] <- NULL
+    if(ncol(mcols(x)) == 0) 
+        mcols(x) <- NULL
     quals <- switch(quality.scoring,
                     phred=PhredQuality(qualities),
                     solexa=SolexaQuality(qualities),

--- a/R/QualityScaledXStringSet.R
+++ b/R/QualityScaledXStringSet.R
@@ -186,11 +186,12 @@ readQualityScaledDNAStringSet <- function(filepath,
                           nrec, skip, seek.first.rec,
                           use.names, with.qualities=TRUE)
     qualities <- mcols(x)[ , "qualities"]
-    ## Clear out the qualities parameter from the SS, since it gets passed 
-    ## into the QSSS constructor via quals anyway
+    ## Clear out the qualities parameter from the DNAStringSet,
+    ## since it gets passed into the QualityScaledXStringSet
+    ## constructor via quals anyway
     ## (otherwise we get a warning that doesn't make sense)
     mcols(x)[,"qualities"] <- NULL
-    if(ncol(mcols(x)) == 0) 
+    if(ncol(mcols(x)) == 0)
         mcols(x) <- NULL
     quals <- switch(quality.scoring,
                     phred=PhredQuality(qualities),
@@ -207,4 +208,3 @@ writeQualityScaledXStringSet <- function(x, filepath,
     writeXStringSet(x, filepath, append, compress, compression_level,
                        format="fastq", qualities=quality(x))
 }
-

--- a/R/QualityScaledXStringSet.R
+++ b/R/QualityScaledXStringSet.R
@@ -187,7 +187,7 @@ readQualityScaledDNAStringSet <- function(filepath,
                           use.names, with.qualities=TRUE)
     qualities <- mcols(x)[ , "qualities"]
     ## Clear out the qualities parameter from the DNAStringSet,
-    ## since it gets passed into the QualityScaledXStringSet
+    ## since it gets passed into the QualityScaledDNAStringSet
     ## constructor via quals anyway
     ## (otherwise we get a warning that doesn't make sense)
     mcols(x)[,"qualities"] <- NULL


### PR DESCRIPTION
Fixes issue #106 

Wipes the `"qualities"` property of `mcols` from the `DNAStringSet` object prior to building it as a `QualityScaledDNAStringSet`. If other `mcols` properties are still present, it still throws a warning. This fixes the warning thrown in `example(readQualityScaledDNAStringSet)`
