### PR TITLE
Fix: Removes length restriction on `writeXStringSet`, `writeQualityScaledXStringSet`

### DIFF
--- a/R/XStringSet-io.R
+++ b/R/XStringSet-io.R
@@ -362,8 +362,11 @@ readAAStringSet <- function(filepath, format="fasta",
         stop(wmsg("'width' must be a single integer"))
     if (!is.integer(width))
         width <- as.integer(width)
-    if (width < 1L)
-        stop(wmsg("'width' must be an integer >= 1"))
+    if (width < 1L) {
+        ## set to maximum possible width
+        ## using `lengths` because the function overrides `width`
+        width <- max(lengths(x))
+    }
     lkup <- get_seqtype_conversion_lookup(seqtype(x), "B")
     .Call2("write_XStringSet_to_fasta",
           x, filexp_list, width, lkup,

--- a/man/XStringSet-io.Rd
+++ b/man/XStringSet-io.Rd
@@ -169,7 +169,7 @@ saveXStringSet(x, objname, dirpath=".", save.dups=FALSE, verbose=TRUE)
 
     If \code{format="fasta"}, the \code{width} argument can be used to
     specify the maximum number of letters per line of sequence.
-    \code{width} must be a single integer.
+    \code{width} must be a single integer, and uses an unbounded width if set to a value less than 1.
 
     If \code{format="fastq"}, the \code{qualities} argument can be used to
     specify the quality strings. \code{qualities} must be a \link{BStringSet}

--- a/tests/testthat/test-XStringSet-io.R
+++ b/tests/testthat/test-XStringSet-io.R
@@ -184,7 +184,7 @@ test_that("Writing XStringSets larger than IOBUF_SIZE functions correctly", {
     xss <- DNAStringSet(c(x1, x2))
     names(xss) <- c("seq1", "seq2")
     exp_output_fasta <- paste0('>seq1', x1, '>seq2', x2)
-    for(w in c(5, 80, 213, 200003, width(xss)[1], width(xss)[2])){
+    for(w in c(5, 80, 213, 200003, width(xss)[1], width(xss)[2], -1)){
       writeXStringSet(xss, tf, width = w)
       opt <- readLines(tf)
       opt <- paste(opt, collapse='')

--- a/tests/testthat/test-XStringSet-io.R
+++ b/tests/testthat/test-XStringSet-io.R
@@ -175,3 +175,21 @@ test_that("XStringSet read/write is correct", {
     unlink(tmpfilefq)
 })
 
+test_that("Writing XStringSets larger than IOBUF_SIZE functions correctly", {
+    ## IOBUF_SIZE is 200,003
+    tf <- tempfile()
+    set.seed(456L)
+    x1 <- paste(sample(DNA_BASES, 400020, replace=TRUE), collapse='')
+    x2 <- paste(sample(DNA_BASES, 200127, replace=TRUE), collapse='')
+    xss <- DNAStringSet(c(x1, x2))
+    names(xss) <- c("seq1", "seq2")
+    exp_output_fasta <- paste0('>seq1', x1, '>seq2', x2)
+    for(w in c(5, 80, 213, 200003, width(xss)[1], width(xss)[2])){
+      writeXStringSet(xss, tf, width = w)
+      opt <- readLines(tf)
+      opt <- paste(opt, collapse='')
+      expect_equal(opt, exp_output_fasta)
+      read_seqs <- readDNAStringSet(tf)
+      expect_true(all(as.character(read_seqs) == as.character(xss)))
+    }
+})

--- a/tests/testthat/test-XStringSet-io.R
+++ b/tests/testthat/test-XStringSet-io.R
@@ -193,3 +193,25 @@ test_that("Writing XStringSets larger than IOBUF_SIZE functions correctly", {
       expect_true(all(as.character(read_seqs) == as.character(xss)))
     }
 })
+
+test_that("Writing QualityScaledXStringSets larger than IOBUF_SIZE functions correctly", {
+    ## IOBUF_SIZE is 200,003
+    tf <- tempfile()
+    set.seed(456L)
+    x1 <- paste(sample(DNA_BASES, 200127, replace=TRUE), collapse='')
+    x2 <- paste(sample(DNA_BASES, 400020, replace=TRUE), collapse='')
+    q1 <- paste(sample(as.character(1:9), 200127, replace=TRUE), collapse='')
+    q2 <- paste(sample(as.character(1:9), 400020, replace=TRUE), collapse='')
+    xss <- DNAStringSet(c(x1, x2))
+    quals <- PhredQuality(c(q1, q2))
+    names(xss) <- c("seq1", "seq2")
+    names(quals) <- c("seq1", "seq2")
+    exp_output_fastq <- paste0("@seq1", x1, "+seq1", q1, "@seq2", x2, "+seq2", q2)
+    qss <- QualityScaledDNAStringSet(xss, quals)
+    writeQualityScaledXStringSet(qss, tf)
+    opt <- paste(readLines(tf), collapse='')
+    expect_equal(opt, exp_output_fastq)
+    read_seqs <- readQualityScaledDNAStringSet(tf)
+    expect_true(all(as.character(read_seqs) == as.character(xss)))
+    expect_true(all(as.character(quality(read_seqs)) == as.character(quals)))
+})


### PR DESCRIPTION
`writeXStringSet` and `writeQualityScaledXStringSet` previously restricted inputs based on the width of sequences due to limitations in the internal I/O buffer. Now arbitrarily long sequences can be written, resulting in support for `width > 200003` for `XStringSet` objects and also support for writing `QualityScaledXStringSet` objects with sequences longer than 200kbp.

More specific changes:
- `writeXStringSet` now supports any integer value for `width`
- `writeXStringSet` called with zero or negative values for `width` will now using unbounded width (i.e., each sequence written on a single line)
- `writeQualityScaledXStringSet` now functions for sequences of arbitrary length, fixing Issue 177 (#117)
- Unit test cases added to cover new functionality. Could consider adding more tests to cover other `SolexaQuality` and `IlluminaQuality`, as well as verifying that the output widths are the correct number of characters.