### PR TITLE
fix: XString comparison operators

### DIFF
--- a/R/XString-class.R
+++ b/R/XString-class.R
@@ -434,6 +434,13 @@ setMethod("==", signature(e1="BString", e2="character"),
 setMethod("==", signature(e1="character", e2="BString"),
     function(e1, e2) e2 == e1
 )
+setMethod("==", signature(e1="XString", e2="character"),
+    ## Coerce to BString to handle things like RNAString("U") == "T"
+    function(e1, e2) as(e1, "BString") == e2
+)
+setMethod("==", signature(e1="character", e2="XString"),
+    function(e1, e2) e1 == as(e2, "BString")
+)
 
 setMethod("!=", signature(e1="XString", e2="XString"),
     function(e1, e2) !(e1 == e2)
@@ -444,7 +451,34 @@ setMethod("!=", signature(e1="BString", e2="character"),
 setMethod("!=", signature(e1="character", e2="BString"),
     function(e1, e2) !(e1 == e2)
 )
+setMethod("!=", signature(e1="XString", e2="character"),
+    function(e1, e2) as(e1, "BString") != e2
+)
+setMethod("!=", signature(e1="character", e2="XString"),
+    function(e1, e2) e1 != as(e2, "BString")
+)
 
+### Comparisons are already implemented for XStringSet objects,
+### so we can just dispatch to that code here.
+setMethod("<=", signature(e1="XString", e2="XString"),
+    function(e1, e2)
+    {
+        if (!comparable_seqtypes(seqtype(e1), seqtype(e2))) {
+            class1 <- class(e1)
+            class2 <- class(e2)
+            stop("comparison between a \"", class1, "\" instance ",
+                 "and a \"", class2, "\" instance ",
+                 "is not supported")
+        }
+        as(e1, "XStringSet") <= as(e2, "XStringSet")
+    }
+)
+setMethod("<=", signature(e1="XString", e2="character"),
+    function(e1, e2) as(e1, "BStringSet") <= e2
+)
+setMethod("<=", signature(e1="character", e2="XString"),
+    function(e1, e2) e1 <= as(e2, "BStringSet")
+)
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### The "substr" and "substring" methods.

--- a/tests/testthat/test-XString-class.R
+++ b/tests/testthat/test-XString-class.R
@@ -137,14 +137,64 @@ test_that("equality methods work as advertised", {
     expect_true(AAString(aastr) != BString(bstr))
     expect_true(bstr == BString(bstr))
 
+    ## comparisons against character
+    expect_true(DNAString("AAA") == "AAA")
+    expect_true(DNAString("AAA") != "BBB")
+    expect_false(RNAString("UUU") == "TTT")
+    expect_true(AAString("UUU") == "UUU")
+    ## these may seem redundant but need to ensure that order doesn't matter
+    expect_true("AAA" == DNAString("AAA"))
+    expect_true("BBB" != DNAString("AAA"))
+    expect_false("TTT" == RNAString("UUU"))
+    expect_true("UUU" == AAString("UUU"))
+
     ## invalid comparisons
-    expect_error(DNAString(dnastr) == AAString(aastr),
+    expect_error(DNAString() == AAString(),
       "comparison between a \"DNAString\" instance and a \"AAString\" instance is not supported")
-    expect_error(DNAString(dnastr) == BString(bstr),
+    expect_error(DNAString() == BString(),
       "comparison between a \"DNAString\" instance and a \"BString\" instance is not supported")
-    expect_error(RNAString(rnastr) == AAString(aastr),
+    expect_error(RNAString() == AAString(),
       "comparison between a \"RNAString\" instance and a \"AAString\" instance is not supported")
-    expect_error(RNAString(rnastr) == BString(bstr),
+    expect_error(RNAString() == BString(),
+      "comparison between a \"RNAString\" instance and a \"BString\" instance is not supported")
+})
+
+test_that("inequality methods work as advertised", {
+    ## Basic cases
+    expect_true(DNAString("AAA") <= DNAString("AAAA"))
+    expect_false(DNAString("AAA") > DNAString("AAAA"))
+    expect_true(DNAString("AAA") <= DNAString("AAA"))
+    expect_true(DNAString("A") <= DNAString("C"))
+    expect_false(DNAString("ATTT") > RNAString("AUUU"))
+    expect_true(AAString("AAA") <= AAString("BBB"))
+    expect_true(BString("Testing") <= BString("ZZZTesting"))
+
+    ## have to check every combination for XString - character comparisons
+    ## due to how dispatch works
+    expect_true(BString("ABCDEFG") <= "ABCDEFG")
+    expect_true(BString("ABCDEFG") <  "ZYXWVUT")
+    expect_true(BString("ABCDEFG") >= "ABCDEFG")
+    expect_false(BString("ABCDEFG") > "ABCDEFG")
+
+    expect_true("ABCDEFG" <= BString("ABCDEFG"))
+    expect_false("ZYXWVUT" < BString("ABCDEFG"))
+    expect_true("ABCDEFG" >= BString("ABCDEFG"))
+    expect_false("ABCDEFG" > BString("ABCDEFG"))
+
+    ## Cases with potentially invalid characters
+    expect_true(DNAString("AAA") < "BBB")
+    expect_true(DNAString("CCC") > "BBB")
+    expect_true(RNAString("UUU") >= "TTT")
+    expect_true(RNAString("UUU") >= "UUU")
+
+    ## invalid comparisons
+    expect_error(DNAString() <= AAString(),
+      "comparison between a \"DNAString\" instance and a \"AAString\" instance is not supported")
+    expect_error(DNAString() <= BString(),
+      "comparison between a \"DNAString\" instance and a \"BString\" instance is not supported")
+    expect_error(RNAString() <= AAString(),
+      "comparison between a \"RNAString\" instance and a \"AAString\" instance is not supported")
+    expect_error(RNAString() <= BString(),
       "comparison between a \"RNAString\" instance and a \"BString\" instance is not supported")
 })
 


### PR DESCRIPTION
Adapted from https://github.com/Bioconductor/XVector/pull/6

Scope of this fix has been narrowed to just operating on XString objects (and their comparison(s) with character) rather than all of XVector.

The buggy behavior previously mentioned in the [Biostrings TODO](https://github.com/Bioconductor/Biostrings/blob/44e8aa36353658a53a8ff7141082c024b6b39b9c/TODO#L62-L114) has been fixed to the following behavior:
```r
> DNAString("A") != "A"
[1] FALSE
> DNAString("A") <= "A"
[1] TRUE
> DNAString("A") >= "A"
[1] TRUE
> DNAString("A") < "A"
[1] FALSE
> DNAString("A") > "A"
[1] FALSE
> DNAString("AAA") == "AAA"
[1] TRUE
> DNAString("AAA") <= "AAA"
[1] TRUE
> BString("AAA") <= "AAA"
[1] TRUE
> DNAString("A") > DNAString("A")
[1] FALSE
> DNAString("C") > DNA_ALPHABET
 [1]  TRUE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE
[13] FALSE  TRUE FALSE  TRUE  TRUE  TRUE
```

Note that there's a bit of a decision to be made with something like `RNAString("U") < "T"` and `RNAString("U") == "T"`. I chose to coerce to BString to use existing previously written methods, since it has consistency with prior work and consistency across inequality and equality comparisons. You could make the argument that `RNAString("U") == "T"` if we're always interpreting letters as bases, but then we get into tricky territory with the inequality operators (i.e., who is to say if `DNAString("A") < DNAString("C")`? Do bases have an inherent ordering?). This solution seems to be the most internally consistent and closest to the behavior I'd expect as a user. It also results in the fewest confusing error messages (handling cases like `DNAString("C") < "E"` is more challenging).

Unit tests have been updated. They're a bit verbose so that we could cover a lot of the possible input variable arrangements.