### PR TITLE
Disable test-coverage github workflow

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,8 +1,9 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
-on:
-  pull_request:
-    branches: [main, master, devel, devel-staging]
+# on:
+#   pull_request:
+#     branches: [main, master, devel, devel-staging]
+on: []
 
 name: test-coverage-nocodecov
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,5 +1,6 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# Uncomment these lines to re-enable workflow for PRs
 # on:
 #   pull_request:
 #     branches: [main, master, devel, devel-staging]


### PR DESCRIPTION
Going to leave it as-is in case we want to revisit this in the future. This should turn off the action for future pull requests.